### PR TITLE
Add test GH workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+name: test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+
+    strategy:
+      fail-fast: false  # don't cancel other matrix jobs when one fails
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install .[test]
+    - name: Run tests
+      run: |
+        pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,10 @@ authors = [
   {name = "Roger H. French", email = "rxf131@case.edu"},
 ]
 
+[project.optional-dependencies]
+test = ["pytest"]
+]
+
 [project.urls]
 "Bug Tracker" = "https://github.com/cwru-sdle/kgc-py/issues"
 "Source Code" = "https://github.com/cwru-sdle/kgc-py"


### PR DESCRIPTION
Now that tests have been added in #8 it would be great setting up a GitHub action to do this automatically.

Also, pytest should be added to the pyproject.toml file as a test depdency.