### PR TITLE
Update GH action versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,9 +17,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies


### PR DESCRIPTION
The current test suite is giving the following warnings due to outdated GH action versions:

![image](https://github.com/cwru-sdle/kgc-py/assets/39184289/90181462-81b5-42fa-94f2-e549de2a784c)

For example this [action run](https://github.com/cwru-sdle/kgc-py/actions/runs/9650482861).