### PR TITLE
Correct capitalization in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
-include kgcPy/*.png
-include kgcPy/*.jpg
-include kgcPy/*.tif
-include kgcPy/*.npy
-include kgcPy/*.csv
+include kgcpy/*.png
+include kgcpy/*.jpg
+include kgcpy/*.tif
+include kgcpy/*.npy
+include kgcpy/*.csv


### PR DESCRIPTION
@bgpierc the package still has an error in it as discussed in #15. The error is due to the incorrect capitalization of kgcpy/kgcPy in the MANIFEST.in file. 

Should be good now, but let's see the tests run successfully before making a new release.

Acknowledging @kandersolar for figuring this out.